### PR TITLE
feat(minotari): Add script to build Android .so libraries

### DIFF
--- a/cw_minotari/android/build.gradle
+++ b/cw_minotari/android/build.gradle
@@ -1,0 +1,53 @@
+group 'com.cakewallet.cw_minotari'
+version '1.0'
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.7.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 34
+
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.cakewallet.cw_minotari'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    sourceSets {
+        main.kotlin.srcDirs += 'src/main/kotlin'
+        main {
+            jniLibs.srcDirs = ['src/main/jniLibs']
+        }
+    }
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 34
+    }
+}

--- a/cw_minotari/android/settings.gradle
+++ b/cw_minotari/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'cw_minotari'

--- a/cw_minotari/android/src/main/kotlin/com/cakewallet/cw_minotari/CwMinotariPlugin.kt
+++ b/cw_minotari/android/src/main/kotlin/com/cakewallet/cw_minotari/CwMinotariPlugin.kt
@@ -1,0 +1,13 @@
+package com.cakewallet.cw_minotari
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+
+class CwMinotariPlugin: FlutterPlugin {
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    // No-op: native library loading is handled by flutter_rust_bridge
+  }
+
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    // No-op
+  }
+}

--- a/cw_minotari/pubspec.yaml
+++ b/cw_minotari/pubspec.yaml
@@ -35,5 +35,9 @@ ffigen:
     entry-points:
       - 'rust/target/minotari_wallet.h'
 
-# Flutter plugin configuration removed - will be added back when implementing real FFI
-# Currently using stub implementation without native code
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: com.cakewallet.cw_minotari
+        pluginClass: CwMinotariPlugin

--- a/scripts/android/build_minotari.sh
+++ b/scripts/android/build_minotari.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -e
+cd "$(dirname "$0")"
+
+CW_MINOTARI_DIR=$(realpath ../..)/cw_minotari
+RUST_DIR="${CW_MINOTARI_DIR}/rust"
+
+if [[ ! -d "$RUST_DIR" ]]; then
+    echo "Rust directory not found: $RUST_DIR"
+    exit 1
+fi
+
+if [[ -z "$ANDROID_HOME" ]]; then
+    echo "ANDROID_HOME is missing, please declare it before building (on macos it is usually $HOME/Library/Android/sdk)"
+    echo "echo > ~/.zprofile"
+    echo "echo 'export ANDROID_HOME=\"\$HOME/Library/Android/sdk\"' > ~/.zprofile"
+    exit 1
+fi
+
+if [[ -z "$ANDROID_NDK_VERSION" ]]; then
+    echo "ANDROID_NDK_VERSION is missing, please declare it before building"
+    echo "You have these versions installed on your system currently:"
+    ls ${ANDROID_HOME}/ndk/ | cat | awk '{ print "- " $1 }'
+    echo "echo > ~/.zprofile"
+    echo "echo 'export ANDROID_NDK_VERSION=.....' > ~/.zprofile"
+    exit 1
+fi
+
+export NDK_PATH="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}"
+export TOOLCHAIN="${NDK_PATH}/toolchains/llvm/prebuilt/$(uname | tr '[:upper:]' '[:lower:]')-x86_64"
+export ANDROID_OUT="${CW_MINOTARI_DIR}/android/src/main/jniLibs"
+export OPENSSL_BASE_DIR="$(realpath ../..)/scripts/torch_dart/simplybs/.buildlib/env"
+
+# Ensure Rust Android targets are installed
+echo "Installing Rust Android targets..."
+rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
+
+cd "$RUST_DIR"
+
+# Build for each Android architecture
+for arch in "armv7" "aarch64" "x86_64"
+do
+    RUST_TARGET=""
+    ARCH_ABI=""
+    AR_PATH=""
+    LINKER_PATH=""
+    OPENSSL_ARCH_DIR=""
+
+    case $arch in
+        "armv7")
+            RUST_TARGET="armv7-linux-androideabi"
+            ARCH_ABI="armeabi-v7a"
+            AR_PATH="${TOOLCHAIN}/bin/llvm-ar"
+            LINKER_PATH="${TOOLCHAIN}/bin/armv7a-linux-androideabi21-clang"
+            OPENSSL_ARCH_DIR="armv7a-linux-androideabi"
+            ;;
+        "aarch64")
+            RUST_TARGET="aarch64-linux-android"
+            ARCH_ABI="arm64-v8a"
+            AR_PATH="${TOOLCHAIN}/bin/llvm-ar"
+            LINKER_PATH="${TOOLCHAIN}/bin/aarch64-linux-android21-clang"
+            OPENSSL_ARCH_DIR="aarch64-linux-android"
+            ;;
+        "x86_64")
+            RUST_TARGET="x86_64-linux-android"
+            ARCH_ABI="x86_64"
+            AR_PATH="${TOOLCHAIN}/bin/llvm-ar"
+            LINKER_PATH="${TOOLCHAIN}/bin/x86_64-linux-android21-clang"
+            OPENSSL_ARCH_DIR="x86_64-linux-android"
+            ;;
+        *)
+            echo "Unknown arch: $arch"
+            exit 1
+            ;;
+    esac
+
+    OPENSSL_DIR="${OPENSSL_BASE_DIR}/${OPENSSL_ARCH_DIR}"
+
+    if [[ ! -d "${OPENSSL_DIR}" ]]; then
+        echo "OpenSSL directory not found: ${OPENSSL_DIR}"
+        echo "Please run ./scripts/android/build_torch.sh first to build OpenSSL"
+        exit 1
+    fi
+
+    echo "Building for ${RUST_TARGET}..."
+    echo "Using OpenSSL from: ${OPENSSL_DIR}"
+
+    # Set environment variables for cross-compilation
+    export AR="${AR_PATH}"
+    export CC="${LINKER_PATH}"
+    export CXX="${LINKER_PATH}++"
+    export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="${TOOLCHAIN}/bin/armv7a-linux-androideabi21-clang"
+    export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${TOOLCHAIN}/bin/aarch64-linux-android21-clang"
+    export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="${TOOLCHAIN}/bin/x86_64-linux-android21-clang"
+
+    # Set OpenSSL paths to use pre-built libraries
+    export OPENSSL_DIR="${OPENSSL_DIR}"
+    export OPENSSL_LIB_DIR="${OPENSSL_DIR}/lib"
+    export OPENSSL_INCLUDE_DIR="${OPENSSL_DIR}/include"
+    export OPENSSL_STATIC=1
+
+    # Build the library
+    cargo build --release --target ${RUST_TARGET}
+
+    # Create output directory
+    DEST_LIB_DIR="${ANDROID_OUT}/${ARCH_ABI}"
+    mkdir -p "${DEST_LIB_DIR}"
+
+    # Copy the library to the jniLibs directory
+    cp "target/${RUST_TARGET}/release/librust_lib_flutter_rust_wallet.so" \
+       "${DEST_LIB_DIR}/librust_lib_flutter_rust_wallet.so"
+
+    echo "Built ${ARCH_ABI} successfully"
+done
+
+echo "All Android architectures built successfully!"

--- a/scripts/prepare_minotari.sh
+++ b/scripts/prepare_minotari.sh
@@ -81,6 +81,25 @@ fi
   fi
 )
 
+#######################################
+# Build Android .so libraries
+#######################################
+
+# Only build Android libraries if ANDROID_HOME is set
+if [ -n "${ANDROID_HOME:-}" ] && [ -n "${ANDROID_NDK_VERSION:-}" ]; then
+  echo "📱 Building Android .so libraries..."
+  (
+    cd "$SCRIPTS_DIR/android" || exit 1
+    if [ -f "build_minotari.sh" ]; then
+      ./build_minotari.sh
+    else
+      echo "⚠️  build_minotari.sh not found, skipping Android build"
+    fi
+  )
+else
+  echo "⏭️  Skipping Android build (ANDROID_HOME or ANDROID_NDK_VERSION not set)"
+fi
+
 
 #######################################
 # Done


### PR DESCRIPTION
- Added `build_minotari.sh` to cross-compile for Android targets(`armv7`, `aarch64`, and `x86_64`), handle dependencies, and copy `.so` files to the output directory.
- Updated `prepare_minotari.sh` to call this script when Android environment variables are set, improving build reliability and developer experience.
- Added minimal Android configuration to bundle native libraries