### PR TITLE
feat(minotari): Refactor wallet credentials to include password and passphrase

### DIFF
--- a/cw_minotari/lib/minotari_wallet.dart
+++ b/cw_minotari/lib/minotari_wallet.dart
@@ -34,10 +34,11 @@ abstract class MinotariWalletBase
     WalletInfo walletInfo,
     DerivationInfo derivationInfo, {
     String? mnemonic,
-    required String passphrase,
+    required String password,
     required this.encryptionFileUtils,
+    this.passphrase,
   })  : _mnemonic = mnemonic,
-        _passphrase = passphrase,
+        _password = password,
         balance = ObservableMap.of({
           CryptoCurrency.xtm: MinotariBalance(
             available: 0,
@@ -57,8 +58,8 @@ abstract class MinotariWalletBase
   StreamSubscription<ScanEventDto>? _scannerSubscription;
   Node? _currentNode;
 
+  final String _password;
   final String? _mnemonic;
-  final String _passphrase;
   final EncryptionFileUtils encryptionFileUtils;
 
   @override
@@ -75,16 +76,16 @@ abstract class MinotariWalletBase
   @override
   String? get seed => _mnemonic;
 
-  /// For Minotari, password is not used for wallet encryption.
-  /// The passphrase is used for BIP39 seed derivation.
+  /// password - for encrypting/decrypting the .keys file
   @override
-  String get password => '';
+  String get password => _password;
 
   /// BIP39 passphrase used for seed derivation
-  String get passphrase => _passphrase;
+  @override
+  final String? passphrase;
 
   @override
-  WalletKeysData get walletKeysData => WalletKeysData(mnemonic: _mnemonic);
+  WalletKeysData get walletKeysData => WalletKeysData(mnemonic: _mnemonic, passphrase: passphrase);
 
   @override
   Object get keys => {};
@@ -106,7 +107,7 @@ abstract class MinotariWalletBase
       await _ffi?.open(network);
 
       // Get the wallet address from the Rust layer (it's persisted there)
-      final address = await _ffi?.getAddress(passphrase: _passphrase);
+      final address = await _ffi?.getAddress(passphrase: passphrase ?? '');
       if (address != null && address.isNotEmpty) {
         walletAddresses.setAddress(address);
       } else {
@@ -139,6 +140,10 @@ abstract class MinotariWalletBase
     }
   }
 
+  /// TODO Sometimes receives an error "AnyhowException(Intermittent error:
+  /// Scanning error: Blockchain connection failed: Failed to get header at
+  /// height 186479)"
+  /// Need to investigate further
   @override
   Future<void> startSync() async {
     try {
@@ -157,7 +162,7 @@ abstract class MinotariWalletBase
       // Start the scanner stream
       final scanStream = _ffi?.startScan(
         baseNodeAddress: nodeUrl,
-        passphrase: _passphrase,
+        passphrase: passphrase ?? '',
         continuous: false, // One-time sync
       );
 
@@ -168,25 +173,36 @@ abstract class MinotariWalletBase
       // Listen to scan events
       _scannerSubscription = scanStream.listen(
         (event) {
-          _handleScanEvent(event);
+          try {
+            _handleScanEvent(event);
+          } catch (e) {
+            printV('Error handling scan event: $e');
+            syncStatus = FailedSyncStatus();
+          }
         },
         onError: (error) {
-          printV('Scanner error: $error');
+          printV('Scanner stream error: $error');
           syncStatus = FailedSyncStatus();
         },
         onDone: () async {
           // Scan completed, update balance and transactions
-          await updateBalance();
-          await updateTransactions();
-          syncStatus = SyncedSyncStatus();
+          try {
+            await updateBalance();
+            await updateTransactions();
+            syncStatus = SyncedSyncStatus();
+          } catch (e) {
+            printV('Error updating after scan: $e');
+            syncStatus = FailedSyncStatus();
+          }
         },
+        cancelOnError: true, // Stop listening after an error
       );
 
       syncStatus = SyncronizingSyncStatus();
     } catch (e) {
       printV('Error starting sync: $e');
       syncStatus = FailedSyncStatus();
-      rethrow;
+      // Don't rethrow - we've already set FailedSyncStatus
     }
   }
 
@@ -220,15 +236,19 @@ abstract class MinotariWalletBase
           },
         );
       },
-      transactionsReady: (dto) async {
+      transactionsReady: (dto) {
         printV('Transactions ready: ${dto.transactions.length} transactions');
-        // Update transactions immediately when discovered
-        await _processNewTransactions(dto.transactions);
+        // Update transactions immediately when discovered (fire-and-forget)
+        _processNewTransactions(dto.transactions).catchError((e) {
+          printV('Error processing new transactions: $e');
+        });
       },
-      transactionsUpdated: (dto) async {
+      transactionsUpdated: (dto) {
         printV('Transactions updated: ${dto.updatedTransactions.length} transactions');
-        // Update existing transactions
-        await _processNewTransactions(dto.updatedTransactions);
+        // Update existing transactions (fire-and-forget)
+        _processNewTransactions(dto.updatedTransactions).catchError((e) {
+          printV('Error processing updated transactions: $e');
+        });
       },
       error: (errorMessage) {
         printV('Scanner error: $errorMessage');
@@ -246,8 +266,11 @@ abstract class MinotariWalletBase
   @override
   Future<void> save() async {
     // Wallet state is saved automatically by the Rust layer
-    // Save the keys file (mnemonic) - Minotari doesn't use password-based encryption
-    await saveKeysFile(password, encryptionFileUtils);
+    // Save the keys file (mnemonic and passphrase)
+    if (!(await WalletKeysFile.hasKeysFile(walletInfo.name, walletInfo.type))) {
+      await saveKeysFile(password, encryptionFileUtils);
+      saveKeysFile(password, encryptionFileUtils, true); // backup
+    }
   }
 
   @override

--- a/cw_minotari/lib/minotari_wallet_service.dart
+++ b/cw_minotari/lib/minotari_wallet_service.dart
@@ -39,7 +39,7 @@ class MinotariWalletService extends WalletService<
     );
 
     final ffi = MinotariFfi(dataPath: path);
-    final passphrase = credentials.passphrase!;
+    final passphrase = credentials.passphrase ?? '';
 
     // Create wallet - get WalletCreationDetails with seed words
     final network = _getNetwork(isTestnet);
@@ -63,7 +63,8 @@ class MinotariWalletService extends WalletService<
       walletInfo,
       derivationInfo,
       mnemonic: mnemonic,
-      passphrase: passphrase,
+      password: credentials.password!,
+      passphrase: credentials.passphrase,
       encryptionFileUtils: _encryptionFileUtils,
     );
     wallet.walletAddresses.setAddress(address);
@@ -85,11 +86,10 @@ class MinotariWalletService extends WalletService<
     }
 
     // Load wallet keys (mnemonic) from encrypted .keys file
-    // Note: Minotari doesn't use password-based wallet encryption
     final keysData = await WalletKeysFile.readKeysFile(
       name,
       getType(),
-      '', // Minotari doesn't use password for .keys file encryption
+      password,
       _encryptionFileUtils,
     );
 
@@ -100,7 +100,8 @@ class MinotariWalletService extends WalletService<
       walletInfo,
       derivationInfo,
       mnemonic: keysData.mnemonic,
-      passphrase: '', // Default passphrase - stored passphrase would be needed for non-empty
+      passphrase: keysData.passphrase,
+      password: password,
       encryptionFileUtils: _encryptionFileUtils,
     );
     await wallet.init();
@@ -135,7 +136,7 @@ class MinotariWalletService extends WalletService<
     final currentWallet = MinotariWallet(
       currentWalletInfo,
       derivationInfo,
-      passphrase: '', // Minotari doesn't use password
+      password: password,
       encryptionFileUtils: _encryptionFileUtils,
     );
 
@@ -166,7 +167,7 @@ class MinotariWalletService extends WalletService<
     );
 
     final ffi = MinotariFfi(dataPath: path);
-    final passphrase = credentials.passphrase!;
+    final passphrase = credentials.passphrase ?? '';
     final walletInfo = credentials.walletInfo!;
 
     // Restore wallet from mnemonic - get WalletCreationDetails with seed words
@@ -190,7 +191,8 @@ class MinotariWalletService extends WalletService<
       walletInfo,
       derivationInfo,
       mnemonic: credentials.mnemonic,
-      passphrase: passphrase,
+      password: credentials.password!,
+      passphrase: credentials.passphrase,
       encryptionFileUtils: _encryptionFileUtils,
     );
     wallet.walletAddresses.setAddress(address);
@@ -227,20 +229,23 @@ class MinotariWalletService extends WalletService<
 class MinotariNewWalletCredentials extends WalletCredentials {
   MinotariNewWalletCredentials({
     required String name,
-    required String passphrase,
+    String? password,
+    String? passphrase,
     WalletInfo? walletInfo,
-  }) : super(name: name, walletInfo: walletInfo, passphrase: passphrase);
+  }) : super(name: name, password: password, walletInfo: walletInfo, passphrase: passphrase);
 }
 
 class MinotariRestoreWalletFromSeedCredentials extends WalletCredentials {
   MinotariRestoreWalletFromSeedCredentials({
     required String name,
+    required String password,
     required this.mnemonic,
     required int height,
-    required String passphrase,
+    String? passphrase,
     WalletInfo? walletInfo,
   }) : super(
          name: name,
+         password: password,
          height: height,
          walletInfo: walletInfo,
          passphrase: passphrase,

--- a/lib/minotari/cw_minotari.dart
+++ b/lib/minotari/cw_minotari.dart
@@ -7,11 +7,13 @@ class CWMinotari extends Minotari {
   @override
   WalletCredentials createMinotariNewWalletCredentials({
     required String name,
-    required String passphrase,
+    String? password,
+    String? passphrase,
     WalletInfo? walletInfo,
   }) =>
       MinotariNewWalletCredentials(
         name: name,
+        password: password,
         passphrase: passphrase,
         walletInfo: walletInfo,
       );
@@ -19,13 +21,15 @@ class CWMinotari extends Minotari {
   @override
   WalletCredentials createMinotariRestoreWalletFromSeedCredentials({
     required String name,
+    required String password,
     required String mnemonic,
     required int height,
-    required String passphrase,
+    String? passphrase,
     WalletInfo? walletInfo,
   }) =>
       MinotariRestoreWalletFromSeedCredentials(
         name: name,
+        password: password,
         mnemonic: mnemonic,
         height: height,
         passphrase: passphrase,

--- a/lib/minotari/minotari.dart
+++ b/lib/minotari/minotari.dart
@@ -20,15 +20,17 @@ abstract class Minotari {
 
   WalletCredentials createMinotariNewWalletCredentials({
     required String name,
-    required String passphrase,
+    String? password,
+    String? passphrase,
     WalletInfo? walletInfo,
   });
 
   WalletCredentials createMinotariRestoreWalletFromSeedCredentials({
     required String name,
+    required String password,
     required String mnemonic,
     required int height,
-    required String passphrase,
+    String? passphrase,
     WalletInfo? walletInfo,
   });
 

--- a/lib/view_model/wallet_new_vm.dart
+++ b/lib/view_model/wallet_new_vm.dart
@@ -168,7 +168,8 @@ abstract class WalletNewVMBase extends WalletCreationVM with Store {
       case WalletType.minotari:
         return minotari!.createMinotariNewWalletCredentials(
           name: name,
-          passphrase: passphrase ?? '',
+          password: walletPassword,
+          passphrase: passphrase,
         );
       case WalletType.none:
       case WalletType.haven:

--- a/lib/view_model/wallet_restore_view_model.dart
+++ b/lib/view_model/wallet_restore_view_model.dart
@@ -234,9 +234,10 @@ abstract class WalletRestoreViewModelBase extends WalletCreationVM with Store {
         case WalletType.minotari:
           return minotari!.createMinotariRestoreWalletFromSeedCredentials(
               name: name,
+              password: password,
               mnemonic: seed,
               height: height,
-              passphrase: passphrase??'',
+              passphrase: passphrase,
           );
         case WalletType.none:
         case WalletType.haven:


### PR DESCRIPTION
- Aligned uses of password and passphrase values with other coins (e.g., Solana)
- Improved scan events handling

Known issue:
If I create a new Minotari wallet and stat scan -> I see: 
`AnyhowException(Intermittent error: Scanning error: Blockchain connection failed: Failed to get header at height 186479)`
But the app seems to be working despite that. 
Needs to be investigated