### PR TITLE
feat: allow to build minotari for `mainnet` and `esmeralda` 

### DIFF
--- a/scripts/android/build_minotari.sh
+++ b/scripts/android/build_minotari.sh
@@ -3,6 +3,25 @@
 set -e
 cd "$(dirname "$0")"
 
+# Usage: ./build_minotari.sh [esmeralda|mainnet]
+# Defaults to mainnet if no argument is provided.
+
+NETWORK_ARG=$1
+echo "Configuring Minotari for network argument: ${NETWORK_ARG}"
+
+case "${NETWORK_ARG}" in
+  *esme* | *esmeralda* )
+    echo "Selected: Esmeralda (Testnet)"
+    export TARI_NETWORK=esme
+    export TARI_TARGET_NETWORK=testnet
+    ;;
+  * )
+    echo "Selected: Mainnet (Default)"
+    export TARI_NETWORK=mainnet
+    export TARI_TARGET_NETWORK=mainnet
+    ;;
+esac
+
 CW_MINOTARI_DIR=$(realpath ../..)/cw_minotari
 RUST_DIR="${CW_MINOTARI_DIR}/rust"
 
@@ -114,4 +133,4 @@ do
     echo "Built ${ARCH_ABI} successfully"
 done
 
-echo "All Android architectures built successfully!"
+echo "All Android architectures built successfully for ${TARI_NETWORK}!"

--- a/scripts/android/build_minotari.sh
+++ b/scripts/android/build_minotari.sh
@@ -6,19 +6,22 @@ cd "$(dirname "$0")"
 # Usage: ./build_minotari.sh [esmeralda|mainnet]
 # Defaults to mainnet if no argument is provided.
 
-NETWORK_ARG=$1
-echo "Configuring Minotari for network argument: ${NETWORK_ARG}"
-
+NETWORK_ARG=${1:-mainnet}
+echo "Configuring Minotari for network: ${NETWORK_ARG}"
 case "${NETWORK_ARG}" in
-  *esme* | *esmeralda* )
+  esmeralda|esme)
     echo "Selected: Esmeralda (Testnet)"
     export TARI_NETWORK=esme
     export TARI_TARGET_NETWORK=testnet
     ;;
-  * )
+  mainnet)
     echo "Selected: Mainnet (Default)"
     export TARI_NETWORK=mainnet
     export TARI_TARGET_NETWORK=mainnet
+    ;;
+  *)
+    echo "Error: Invalid network specified: '${NETWORK_ARG}'. Supported options are 'mainnet' or 'esmeralda'." >&2
+    exit 1
     ;;
 esac
 

--- a/scripts/ios/build_minotari.sh
+++ b/scripts/ios/build_minotari.sh
@@ -7,6 +7,25 @@
 set -e
 cd "$(dirname "$0")"
 
+# Usage: ./build_minotari.sh [esmeralda|mainnet]
+# Defaults to mainnet if no argument is provided.
+
+NETWORK_ARG=$1
+echo "Configuring Minotari for network argument: ${NETWORK_ARG}"
+
+case "${NETWORK_ARG}" in
+  *esme* | *esmeralda* )
+    echo "Selected: Esmeralda (Testnet)"
+    export TARI_NETWORK=esme
+    export TARI_TARGET_NETWORK=testnet
+    ;;
+  * )
+    echo "Selected: Mainnet (Default)"
+    export TARI_NETWORK=mainnet
+    export TARI_TARGET_NETWORK=mainnet
+    ;;
+esac
+
 CW_ROOT=$(realpath ../..);
 CW_MINOTARI_DIR="${CW_ROOT}/cw_minotari"
 RUST_DIR="${CW_MINOTARI_DIR}/rust"
@@ -80,4 +99,4 @@ fi
 rm -rf "${SIMULATOR_FAT_DIR}"
 
 echo ""
-echo "iOS Minotari library build complete!"
+echo "iOS Minotari library build complete for ${TARI_NETWORK}!"

--- a/scripts/ios/build_minotari.sh
+++ b/scripts/ios/build_minotari.sh
@@ -10,19 +10,22 @@ cd "$(dirname "$0")"
 # Usage: ./build_minotari.sh [esmeralda|mainnet]
 # Defaults to mainnet if no argument is provided.
 
-NETWORK_ARG=$1
-echo "Configuring Minotari for network argument: ${NETWORK_ARG}"
-
+NETWORK_ARG=${1:-mainnet}
+echo "Configuring Minotari for network: ${NETWORK_ARG}"
 case "${NETWORK_ARG}" in
-  *esme* | *esmeralda* )
+  esmeralda|esme)
     echo "Selected: Esmeralda (Testnet)"
     export TARI_NETWORK=esme
     export TARI_TARGET_NETWORK=testnet
     ;;
-  * )
+  mainnet)
     echo "Selected: Mainnet (Default)"
     export TARI_NETWORK=mainnet
     export TARI_TARGET_NETWORK=mainnet
+    ;;
+  *)
+    echo "Error: Invalid network specified: '${NETWORK_ARG}'. Supported options are 'mainnet' or 'esmeralda'." >&2
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
Updates **android** and **ios** build scripts to accept parameter (esmeralda|mainnet) to specify the network.

```sh
# Usage: ./build_minotari.sh [esmeralda|mainnet]
```